### PR TITLE
Write out Name Objects as UTF-8

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -471,7 +471,7 @@ class NameObject(str, PdfObject):
     surfix = b_("/")
 
     def writeToStream(self, stream, encryption_key):
-        stream.write(b_(self))
+        stream.write(self.encode('utf8'))
 
     def readFromStream(stream, pdf):
         debug = False


### PR DESCRIPTION
The PDF spec describes name objects as utf-8 in general (see Appendix H, 3.2.4 Name Objects), and anything in latin-1 is going to have the same byte representation.